### PR TITLE
Fix formatting for real-time queries guide

### DIFF
--- a/src/topics/realtime/index.md
+++ b/src/topics/realtime/index.md
@@ -15,8 +15,8 @@ The following sections describe both real-time query types in detail. For inform
 protocol, see our [Websocket API Docs](../../websockets/).
 
 <div class="warning"><strong>Real-Time SDK:</strong> 
-To use real-time features, you mus include RxJS
-
+To use real-time features, you must include RxJS.
+</div>
 
 ## Self-Maintaining Queries
 


### PR DESCRIPTION
Hi,

the formatting on the guide for real-time queries is currently broken (https://www.baqend.com/guide/topics/realtime/), where everything appears in a large yellow "warning" box.

I went ahead and fixed it along with a typo.